### PR TITLE
priorityClassName support for redis-commander helm chart

### DIFF
--- a/charts/redis-commander/Chart.yaml
+++ b/charts/redis-commander/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis-commander
 description: A Helm chart for redis-commander
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: latest
 annotations:
   category: Database

--- a/charts/redis-commander/templates/deployment.yaml
+++ b/charts/redis-commander/templates/deployment.yaml
@@ -109,3 +109,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/charts/redis-commander/values.yaml
+++ b/charts/redis-commander/values.yaml
@@ -127,6 +127,8 @@ lifecycle: {}
 
 extraManifests: []
 
+priorityClassName: ""
+
 tests:
   image:
     registry: docker.io


### PR DESCRIPTION
added support for kubernetes [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)

Value is optional and default is ""
If value is not set or empty then priorityClassName will be ignored in deployment